### PR TITLE
cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,4 +102,21 @@ If you want to transfer it somewhere else, you can find the tar file under your 
 
 ## Exporting from IBM License Metric Tool sources
 
-TBD
+_Prerequisite_: API Token is required to get data from IBM License Metric Tool (ILMT). Login to your ILMT environment, go to _Profile_ and click _Show token_ under API Token section.
+
+First step is to configure ILMT data source. Execute following command
+
+`datactl sources add ilmt`
+
+and provide ILMT hostname, port number and token
+
+To pull data from ILMT, execute command
+
+`datactl export pull --source-type=ilmt`
+
+First time you will be asked to provide start date. Next time last synchronization date is stored in config file and will be updated to pull data from last synchronization date.
+
+To push data to Red Hat Marketplace execute command
+
+`datactl export push`
+

--- a/README.md
+++ b/README.md
@@ -8,7 +8,8 @@
 - [Installation](#installation)
 - [Usage](#usage)
 - [Getting started](#getting-started)
-- [Export](#export)
+- [Exporting from DataService sources](#exporting-from-dataservice-sources)
+- [Exporting from IBM License Metric Tool sources](#exporting-from-ibm-license-metric-tool-sources)
 
 <!-- markdown-toc end -->
 
@@ -54,15 +55,20 @@ Datactl tool can be used standalone. Just move oc-datactl to your path and use `
 
 5. Now you're configured. You can start using the export commands.
 
-## Export
+## Exporting from DataService sources
 
 Recommended approach is to run the commands in this order:
 
 ```sh
 // Must be logged in to the cluster
-oc datactl export pull
 
-// If you're in a connect
+// Add the dataservice as a source, to which you are logged into with your current context
+datactl sources add dataservice --use-default-context --allow-self-signed=true
+
+// Pull the data from dataservice sources
+oc datactl export pull --source-type=dataservice
+
+// If you're connected to the internet
 oc datactl export push
 
 // If no errors from push.
@@ -71,6 +77,11 @@ oc datactl export commit
 
 Let's break down what each one is doing.
 
+`datactl sources add dataservice --use-default-context --allow-self-signed=true`
+
+- Adds the default-context cluster's dataservice as a source for pulling
+- Writes the source data-service-endpoint to `~/.datactl/config`
+
 `oc datactl export pull`
 
 - Pulls files from data service and stores them in a tar file under your `~/.datactl/data` folder.
@@ -78,7 +89,7 @@ Let's break down what each one is doing.
 
 `oc datactl export push`
 
-- Pushes the files pulled to Red Hat Marketplace.
+- Files pulled by the previous command are pushed to Red Hat Marketplace.
 - If this process errors, do not commit. Retry the export push or open a support ticket.
 
 `oc datactl export commit`
@@ -88,3 +99,7 @@ Let's break down what each one is doing.
 - After some time, the files in dataservice will be cleaned up to save space.
 
 If you want to transfer it somewhere else, you can find the tar file under your `~/.datactl/data/` directory.
+
+## Exporting from IBM License Metric Tool sources
+
+TBD

--- a/cmd/datactl/app/metering/export_pull.go
+++ b/cmd/datactl/app/metering/export_pull.go
@@ -53,11 +53,9 @@ var (
 )
 
 const (
-	ILMT        string = "ILMT"
-	DATASERVICE string = "DataService"
-	EMPTY       string = ""
-	StartDate          = "startDate"
-	EndDate            = "endDate"
+	EMPTY     string = ""
+	StartDate        = "startDate"
+	EndDate          = "endDate"
 )
 
 func NewCmdExportPull(rhmFlags *config.ConfigFlags, f cmdutil.Factory, ioStreams genericclioptions.IOStreams) *cobra.Command {
@@ -70,7 +68,7 @@ func NewCmdExportPull(rhmFlags *config.ConfigFlags, f cmdutil.Factory, ioStreams
 	cmd := &cobra.Command{
 		Use:                   "pull all [(--source-type SOURCE_TYPE) (--source-name SOURCE_NAME) (--startdate STARTDATE) (--enddate ENDDATE)]",
 		DisableFlagsInUseLine: true,
-		Short:                 i18n.T("Pulls files from Dataservice Operator/IBM Licence Metric Tool"),
+		Short:                 i18n.T("Pulls files from Dataservice Operator or IBM License Metric Tool"),
 		Long:                  output.ReplaceCommandStrings(pullLong),
 		Example:               output.ReplaceCommandStrings(pullExample),
 		Run: func(cmd *cobra.Command, args []string) {
@@ -145,7 +143,9 @@ func (e *exportPullOptions) Complete(cmd *cobra.Command, args []string) error {
 func (e *exportPullOptions) Validate() error {
 	for name := range e.rhmRawConfig.Sources {
 		s := e.rhmRawConfig.Sources[name]
-		if s.Type == "ILMT" {
+
+		switch s.Type {
+		case api.ILMT:
 			if e.startDate == EMPTY {
 				if e.rhmRawConfig.ILMTEndpoints[s.Name].LastPulldate == EMPTY {
 					startDate, err := e.promptStartDate()
@@ -235,10 +235,16 @@ func (e *exportPullOptions) Validate() error {
 				os.Exit(1)
 			}
 
-		} else if s.Type == "DataService" {
-			continue
+		case api.DataService:
+
+		default:
+			e.printer.HumanOutput(func(ho *output.HumanOutput) *output.HumanOutput {
+				p := ho
+				p.Infof(i18n.T("Unsupported source type"))
+				return p
+			})
+			os.Exit(1)
 		}
-		break
 	}
 
 	return nil
@@ -261,12 +267,12 @@ func (e *exportPullOptions) Run() error {
 	for name := range e.rhmRawConfig.Sources {
 		s := e.rhmRawConfig.Sources[name]
 
-		if ((e.sourceType == EMPTY && e.sourceName == EMPTY) || (strings.EqualFold(e.sourceType, s.Type.String()) || strings.EqualFold(e.sourceName, s.Name))) && (strings.EqualFold(s.Type.String(), DATASERVICE)) {
+		if ((e.sourceType == EMPTY && e.sourceName == EMPTY) || (strings.EqualFold(e.sourceType, s.Type.String()) || strings.EqualFold(e.sourceName, s.Name))) && (strings.EqualFold(s.Type.String(), string(api.DataService))) {
 			err := e.DataServicePullBase(s, ctx, currentMeteringExport, bundleFile)
 			if err != nil {
 				continue
 			}
-		} else if ((e.sourceType == EMPTY && e.sourceName == EMPTY) || (strings.EqualFold(e.sourceType, s.Type.String()) || strings.EqualFold(e.sourceName, s.Name))) && (strings.EqualFold(s.Type.String(), ILMT)) {
+		} else if ((e.sourceType == EMPTY && e.sourceName == EMPTY) || (strings.EqualFold(e.sourceType, s.Type.String()) || strings.EqualFold(e.sourceName, s.Name))) && (strings.EqualFold(s.Type.String(), string(api.ILMT))) {
 			_, _, err := e.IlmtPullBase(s, ctx, currentMeteringExport, bundleFile)
 			if err != nil {
 				continue

--- a/cmd/datactl/app/sources/add/add_dataservice.go
+++ b/cmd/datactl/app/sources/add/add_dataservice.go
@@ -32,6 +32,9 @@ var (
 		The command will attempt to resolve the Dataservice URL using the kubernetes context provided.`))
 
 	configInitExample = templates.Examples(i18n.T(`
+		# Initialize the source, using the default context and a self signed cert.
+		{{ .cmd }} sources add dataservice --use-default-context --allow-self-signed=true
+
 		# Initialize the config, prompting for a context to select.
 		{{ .cmd }} sources add dataservice
 

--- a/hack/generate-docs.go
+++ b/hack/generate-docs.go
@@ -22,8 +22,10 @@ import (
 	"github.com/spf13/cobra/doc"
 )
 
+// For some reason, Setenv is not influencing the default path for cache-dir in generated doc
+// https://github.com/kubernetes/cli-runtime/blob/v0.22.2/pkg/genericclioptions/config_flags.go#L59
 func init() {
-	os.Setenv("HOME", "$HOME")
+	os.Setenv("HOME", "/home/user")
 }
 
 func main() {

--- a/pkg/clients/ilmt/ilmtresponse.go
+++ b/pkg/clients/ilmt/ilmtresponse.go
@@ -72,7 +72,7 @@ type ProductUsageTransformedEvent struct {
 }
 
 type ProductUsageTransformedEventData struct {
-	AccountId            string `json:"accountId"`
+	//AccountId            string `json:"accountId"`
 	AdditionalAttributes `json:"additionalAttributes"`
 	EndDate              int64           `json:"end"`
 	StartDate            int64           `json:"start"`

--- a/pkg/datactl/config/client_builder.go
+++ b/pkg/datactl/config/client_builder.go
@@ -247,7 +247,7 @@ func (config *DirectClientConfig) IlmtClientConfig(source api.Source) (*ilmt.Ilm
 	ilmtConfig, exists := datactlConfig.ILMTEndpoints[source.Name]
 
 	if !exists {
-		return nil, fmt.Errorf("ilmt host with name %s not found", source.Name)
+		return nil, fmt.Errorf("ILMT host with name %s not found", source.Name)
 	}
 
 	ilmt, err := clients.ProvideIlmtSource(ilmtConfig)

--- a/pkg/sources/source_ilmt.go
+++ b/pkg/sources/source_ilmt.go
@@ -1,12 +1,24 @@
 package sources
 
 import (
+	"archive/tar"
+	"bytes"
+	"compress/gzip"
 	"context"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"strings"
 
+	"emperror.dev/errors"
 	"github.com/redhat-marketplace/datactl/pkg/bundle"
 	"github.com/redhat-marketplace/datactl/pkg/clients/ilmt"
 	"github.com/redhat-marketplace/datactl/pkg/datactl/api"
+	dataservicev1 "github.com/redhat-marketplace/datactl/pkg/datactl/api/dataservice/v1"
 	"github.com/redhat-marketplace/datactl/pkg/printers"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 const (
@@ -57,12 +69,133 @@ func (i *ilmtSource) Pull(
 		EndDate:   endDate,
 	}
 
-	productCount, productUsageRespStr, err := i.ilmt.FetchUsageData(ctx, dateRangeOptions)
+	_, productUsageRespStr, err := i.ilmt.FetchUsageData(ctx, dateRangeOptions)
 
 	if err != nil {
 		return -1, err
 	}
 
 	i.productUsageResponseStr = productUsageRespStr
-	return productCount, nil
+
+	// create temporary directory
+	tempDir, err := ioutil.TempDir("", "iltmdata")
+	if err != nil {
+		return 0, err
+	}
+
+	// create file with received data and manifest in temporary directory
+	err = CreateFileFromString(filepath.Join(tempDir, "ilmtdata.json"), productUsageRespStr)
+	if err != nil {
+		return 0, err
+	}
+
+	CreateFileFromString(filepath.Join(tempDir, "manifest.json"), "{\"version\":\"1\",\"type\":\"accountMetrics\"}")
+	if err != nil {
+		return 0, err
+	}
+
+	var buffer bytes.Buffer
+
+	// create archive file
+	err = Tar(tempDir, &buffer)
+	if err != nil {
+		return 0, err
+	}
+
+	reportFileName := fmt.Sprintf("upload-ilmt-%s-%s.tar.gz", dateRangeOptions.StartDate, dateRangeOptions.EndDate)
+
+	// create new bundle file
+	w, err := bundle.NewFile(reportFileName, int64(buffer.Len()))
+	if err != nil {
+		return 0, err
+	}
+
+	w.Write(buffer.Bytes())
+
+	// remove temporary directory
+	defer os.RemoveAll(tempDir)
+
+	ilmtFile := &dataservicev1.FileInfoCTLAction{
+		Action: dataservicev1.Pull,
+		FileInfo: &dataservicev1.FileInfo{
+			Source:     "ilmt",
+			SourceType: "report",
+			Size:       uint32(buffer.Len()),
+			MimeType:   "application/gzip",
+			CreatedAt:  &v1.Time{},
+		},
+	}
+	ilmtFile.Name = reportFileName
+
+	currentMeteringExport.Files = append(currentMeteringExport.Files, ilmtFile)
+
+	return 1, nil
+}
+
+// Creates file with given data content
+func CreateFileFromString(outFile string, data string) error {
+	f, err := os.Create(outFile)
+	if err != nil {
+		return err
+	}
+
+	_, err = f.WriteString(data)
+
+	if err != nil {
+		f.Close()
+		return err
+	}
+
+	f.Close()
+
+	return nil
+}
+
+func Tar(src string, writers ...io.Writer) error {
+	if _, err := os.Stat(src); err != nil {
+		return fmt.Errorf("unable to tar files - %v", err.Error())
+	}
+
+	mw := io.MultiWriter(writers...)
+
+	gzw := gzip.NewWriter(mw)
+	defer gzw.Close()
+
+	tw := tar.NewWriter(gzw)
+	defer tw.Close()
+
+	return filepath.Walk(src, func(file string, fi os.FileInfo, errIn error) error {
+
+		if errIn != nil {
+			return errors.Wrap(errIn, "failed to tar files")
+		}
+
+		if !fi.Mode().IsRegular() {
+			return nil
+		}
+
+		header, err := tar.FileInfoHeader(fi, fi.Name())
+		if err != nil {
+			return errors.Wrap(err, "failed to create new dir")
+		}
+
+		header.Name = strings.TrimPrefix(strings.ReplaceAll(file, src, ""), string(filepath.Separator))
+
+		if err = tw.WriteHeader(header); err != nil {
+			return errors.Wrap(err, "failed to write header")
+		}
+
+		f, err := os.Open(file)
+		if err != nil {
+			return errors.Wrap(err, "failed to open file for taring")
+		}
+
+		if _, err := io.Copy(tw, f); err != nil {
+			return errors.Wrap(err, "failed to copy data")
+		}
+
+		f.Close()
+
+		return nil
+	})
 }


### PR DESCRIPTION
Fix some of the outstanding comments in pull/11
- Display error with information about unsupported source type
  - use switch and use api.Type instead of dupe string consts
- change to upper case ILMT
- Pulls files from RHM Operator's Dataservice or IBM Licence Metric Tool
- Comments about auto-generate doc, it seems it should be consuming os.Getenv(HOME), but it's not

---


Can continue to use this branch/PR to address items in symposium 25448
- Update README with dataservice sources steps