### PR TITLE
chore: use go install ginkgo

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,8 +15,8 @@ jobs:
           go-version: 1.19.1
       - name: Ginkgo
         run: |
-          go get github.com/onsi/ginkgo/ginkgo
-          go get github.com/onsi/gomega/...
+          go install github.com/onsi/ginkgo/ginkgo
+          go install github.com/onsi/gomega/...
 
       - name: Test
         run: ginkgo -r --randomizeAllSpecs --randomizeSuites --failOnPending --cover --trace --race --progress


### PR DESCRIPTION
use go install instead of get for go1.19.1