### PR TITLE
fix: go1.19.6

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.19.5
+          go-version: 1.19.6
 
       - name: Build
         run: go build -v ./...

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,7 +12,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.19.5
+          go-version: 1.19.6
       - name: Ginkgo
         run: |
           go install github.com/onsi/ginkgo/v2/ginkgo
@@ -29,7 +29,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.19.5
+          go-version: 1.19.6
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v2
         with:

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,6 +1,6 @@
 before:
   hooks:
-    - go mod tidy -go=1.17 && go mod tidy -go=1.19.5
+    - go mod tidy -go=1.17 && go mod tidy -go=1.19.6
     - find . -type f -name "*.go" | xargs addlicense -c "IBM Corporation."
 env:
   - CGO_ENABLED=0


### PR DESCRIPTION
update to go1.19.6 for [CVE-2022-41724](https://www.mend.io/vulnerability-database/CVE-2022-41724)