### PR TITLE
Feature/fips

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -42,7 +42,7 @@ jobs:
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v1
+      uses: github/codeql-action/init@v2
       with:
         languages: ${{ matrix.language }}
         # If you wish to specify custom queries, you can do so here or in a config file.
@@ -53,7 +53,7 @@ jobs:
     # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
     # If this step fails, then you should remove it and run the build manually (see below)
     - name: Autobuild
-      uses: github/codeql-action/autobuild@v1
+      uses: github/codeql-action/autobuild@v2
 
     # ℹ️ Command-line programs to run using the OS shell.
     # 📚 https://git.io/JvXDl
@@ -67,4 +67,4 @@ jobs:
     #   make release
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v1
+      uses: github/codeql-action/analyze@v2

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -54,7 +54,7 @@ jobs:
         with:
           distribution: goreleaser
           version: latest
-          args: release --snapshot --rm-dist
+          args: release --snapshot --clean
 
       - name: Archive build
         if: github.ref != 'refs/heads/main'

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.19.10
+          go-version: 1.19.11
 
       - name: Build
         run: go build -v ./...

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,7 +12,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.19.10
+          go-version: 1.19.11
       - name: Ginkgo
         run: |
           go install github.com/onsi/ginkgo/v2/ginkgo
@@ -29,7 +29,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.19.10
+          go-version: 1.19.11
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v2
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,7 +35,7 @@ jobs:
         with:
           distribution: goreleaser
           version: latest
-          args: release --rm-dist
+          args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GITHUB_REPOSITORY: ${{github.repository}}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,3 +39,35 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GITHUB_REPOSITORY: ${{github.repository}}
+  docker:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 1
+      - name: Get TAG
+        id: get_tag
+        run: echo TAG=${GITHUB_REF#refs/tags/} >> $GITHUB_ENV
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+      - name: Login to container registry
+        uses: docker/login-action@v2
+        with:
+          registry: quay.io/rh-marketplace
+          username: ${{secrets['quayUser']}}
+          password: ${{secrets['quayPassword']}}
+      - name: Release build
+        id: release_build
+        uses: docker/build-push-action@v3
+        with:
+          outputs: "type=registry,push=true"
+          platforms: linux/amd64,linux/arm64,linux/ppc64le,linux/s390x
+          build-args: |
+            Version=${{ env.TAG }}
+            GitCommit=${{ github.sha }}
+          tags: |
+            quay.io/rh-marketplace/datactl:${{ github.sha }}
+            quay.io/rh-marketplace/datactl:${{ env.TAG }}
+            quay.io/rh-marketplace/datactl:latest

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,6 +1,6 @@
 before:
   hooks:
-    - go mod tidy -go=1.17 && go mod tidy -go=1.19.10
+    - go mod tidy -go=1.17 && go mod tidy -go=1.19.11
     - find . -type f -name "*.go" | xargs addlicense -c "IBM Corporation."
 env:
   - CGO_ENABLED=0

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -44,12 +44,14 @@ builds:
       - ppc64le
 archives:
   - id: tar
-    name_template: '{{ .ProjectName }}_{{ .Os }}_{{ .Arch }}'
-    replacements:
-      amd64: x86_64
-      darwin: Darwin
-      linux: Linux
-      windows: Windows
+    name_template: >-
+      {{ .ProjectName }}_
+      {{- title .Os }}_
+      {{- if eq .Arch "amd64" }}x86_64
+      {{- else if eq .Arch "darwin" }}Darwin
+      {{- else if eq .Arch "linux" }}Linux
+      {{- else if eq .Arch "windows" }}Windows
+      {{- else }}{{ .Arch }}{{ end }}
     builds:
       - datactl
       - datactl-arm64

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,19 @@
+FROM registry.access.redhat.com/ubi8/go-toolset AS build
+
+# Binary destination
+RUN mkdir -p /opt/app-root/src/go/bin
+
+# HOME=/opt/app-root/src/
+# Mount code, build cache, mod cache
+# cache id must be set to get desired uid for mount
+RUN --mount=type=bind,source=.,readonly,target=/opt/app-root/src/go/src/github.com/redhat-marketplace/datactl \
+    --mount=type=cache,id=go-build,uid=1001,gid=0,target=/opt/app-root/src/.cache/go-build \
+    --mount=type=cache,id=mod,uid=1001,gid=0,target=/opt/app-root/src/go/pkg/mod \
+    cd /opt/app-root/src/go/src/github.com/redhat-marketplace/datactl && \
+    go mod download && \
+    GOFLAGS="-buildvcs=false" go install ./cmd/datactl
+
+FROM registry.access.redhat.com/ubi8/ubi-micro
+COPY --from=build /opt/app-root/src/go/bin/datactl .
+ENV OPENSSL_FORCE_FIPS_MODE=1
+CMD ./datactl

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,6 +15,7 @@ RUN --mount=type=bind,source=.,readonly,target=/opt/app-root/src/go/src/github.c
     --mount=type=cache,id=go-build,uid=1001,gid=0,target=/opt/app-root/src/.cache/go-build \
     --mount=type=cache,id=mod,uid=1001,gid=0,target=/opt/app-root/src/go/pkg/mod \
     cd /opt/app-root/src/go/src/github.com/redhat-marketplace/datactl && \
+    go version && \
     go mod download && \
     GOFLAGS="-buildvcs=false" go install ./cmd/datactl && \
     go install github.com/acardace/fips-detect@latest

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,12 @@
 FROM registry.access.redhat.com/ubi8/go-toolset AS build
+ARG TARGETPLATFORM
+ARG BUILDPLATFORM
+ARG TARGETOS
+ARG TARGETARCH
 
-# Binary destination
-RUN mkdir -p /opt/app-root/src/go/bin
+# Binary and pkg destination
+RUN mkdir -p /opt/app-root/src/go/bin && \
+    mkdir -p /opt/app-root/src/go/pkg/
 
 # HOME=/opt/app-root/src/
 # Mount code, build cache, mod cache
@@ -11,9 +16,20 @@ RUN --mount=type=bind,source=.,readonly,target=/opt/app-root/src/go/src/github.c
     --mount=type=cache,id=mod,uid=1001,gid=0,target=/opt/app-root/src/go/pkg/mod \
     cd /opt/app-root/src/go/src/github.com/redhat-marketplace/datactl && \
     go mod download && \
-    GOFLAGS="-buildvcs=false" go install ./cmd/datactl
+    GOFLAGS="-buildvcs=false" go install ./cmd/datactl && \
+    go install github.com/acardace/fips-detect@latest
 
-FROM registry.access.redhat.com/ubi8/ubi-micro
-COPY --from=build /opt/app-root/src/go/bin/datactl .
+
+FROM registry.access.redhat.com/ubi8/ubi-minimal
+ARG TARGETPLATFORM
+ARG BUILDPLATFORM
+ARG TARGETOS
+ARG TARGETARCH
+
+COPY --from=build /opt/app-root/src/go/bin/datactl /usr/local/bin/datactl
+COPY --from=build /opt/app-root/src/go/bin/fips-detect /usr/local/bin/fips-detect
+COPY entrypoint.sh .
+
 ENV OPENSSL_FORCE_FIPS_MODE=1
-CMD ./datactl
+
+ENTRYPOINT ["./entrypoint.sh"]

--- a/Makefile
+++ b/Makefile
@@ -55,16 +55,16 @@ generate: validate-go-version tools
 
 .PHONY: install
 install: goreleaser
-	goreleaser build --skip-validate --single-target --id datactl --rm-dist
+	goreleaser build --skip-validate --single-target --id datactl --clean
 	cp $(shell find dist -type f -name datactl | xargs) /usr/local/bin/
 
 .PHONY: test-release
 test-release: goreleaser
-	goreleaser release --skip-publish --skip-announce --skip-validate --rm-dist
+	goreleaser release --skip-publish --skip-announce --skip-validate --clean
 
 .PHONY: release
 release: goreleaser
-	goreleaser release --rm-dist
+	goreleaser release --clean
 
 .PHONY: goreleaser
 goreleaser:

--- a/Makefile
+++ b/Makefile
@@ -11,6 +11,10 @@ GO_VERSION_VALIDATION_ERR_MSG = Golang version is not supported, please update t
 GOBIN := $(shell pwd)/bin
 PATH := $(GOBIN):$(PATH)
 
+IMAGE_REGISTRY ?= localhost
+IMAGE_NAME ?= datactl
+IMAGE_TAG ?= latest
+
 export PATH
 export GOBIN
 
@@ -70,3 +74,9 @@ tools:
 	go mod download
 	go install "k8s.io/code-generator/cmd/conversion-gen@v0.24.12"	
 	go install "sigs.k8s.io/controller-tools/cmd/controller-gen@v0.10.0"
+
+docker-build:
+	docker build -t $(IMAGE_REGISTRY)/$(IMAGE_NAME):$(IMAGE_TAG) .
+
+docker-push:
+	docker push $(IMAGE_REGISTRY)/$(IMAGE_NAME):$(IMAGE_TAG)

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Datactl tool can be used standalone. Just move oc-datactl to your path and use `
 
 2. Log in to your cluster.
 
-3. Setup your configuration.
+3. Setup your configuration. When prompted, provide the [pull secret token](https://marketplace.redhat.com/) as the `Upload API Secret`.
 
    ```sh
    oc datactl config init
@@ -132,7 +132,7 @@ A containerized FIPS enabled version of datactl is provided, built with Red Hat'
    ```
    mkdir -p $HOME/.datactl
    ```
-2. Setup your configuration, binding the `.datactl` and `.kube` directories
+2. Setup your configuration, binding the `.datactl` and `.kube` directories, and providing the marketplace api endpoint and [pull secret token](https://marketplace.redhat.com/en-us/account/keys)
    ```
    docker run --rm \
    --mount type=bind,source=$HOME/.datactl,target=/root/.datactl \

--- a/README.md
+++ b/README.md
@@ -160,7 +160,7 @@ A containerized FIPS enabled version of datactl is provided, built with Red Hat'
    --name datactl \
    --mount type=bind,source=$HOME/.datactl,target=/root/.datactl \
    --mount type=bind,source=$HOME/.kube,target=/root/.kube \
-   quay.io/rh-marketplace/datactl:latest export pull
+   quay.io/rh-marketplace/datactl:latest export push
    ```
 6. Commit
    ```

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@
 - [Getting started](#getting-started)
 - [Exporting from DataService sources](#exporting-from-dataservice-sources)
 - [Exporting from IBM License Metric Tool sources](#exporting-from-ibm-license-metric-tool-sources)
+- [Using the FIPS enabled datactl container](#using-the-fips-enabled-datactl-container)
 
 <!-- markdown-toc end -->
 
@@ -122,3 +123,50 @@ To push data to Red Hat Marketplace execute command
 
 `datactl export push`
 
+## Using the FIPS enabled datactl container
+
+A containerized FIPS enabled version of datactl is provided, built with Red Hat's [go-toolset](https://developers.redhat.com/articles/2022/05/31/your-go-application-fips-compliant)
+
+
+1. Create the `.datactl` directory locally on the host
+   ```
+   mkdir -p $HOME/.datactl
+   ```
+2. Setup your configuration, binding the `.datactl` and `.kube` directories
+   ```
+   docker run --rm \
+   --mount type=bind,source=$HOME/.datactl,target=/root/.datactl \
+   --mount type=bind,source=$HOME/.kube,target=/root/.kube \
+   quay.io/rh-marketplace/datactl:latest config init --api marketplace.redhat.com --token ${TOKEN}
+   ```
+3. Add a data source, such as `dataservice` from your current OpenShift cluster context
+   ```
+   docker run --rm \
+   --mount type=bind,source=$HOME/.datactl,target=/root/.datactl \
+   --mount type=bind,source=$HOME/.kube,target=/root/.kube \
+   quay.io/rh-marketplace/datactl:latest sources add dataservice --insecure-skip-tls-verify=true --use-default-context --allow-self-signed=true --namespace=redhat-marketplace
+   ```
+4. Pull from the data source
+   ```
+   docker run --rm \
+   --name datactl \
+   --mount type=bind,source=$HOME/.datactl,target=/root/.datactl \
+   --mount type=bind,source=$HOME/.kube,target=/root/.kube \
+   quay.io/rh-marketplace/datactl:latest export pull
+   ```
+5. Push data to Red Hat Marketplace
+   ```
+   docker run --rm \
+   --name datactl \
+   --mount type=bind,source=$HOME/.datactl,target=/root/.datactl \
+   --mount type=bind,source=$HOME/.kube,target=/root/.kube \
+   quay.io/rh-marketplace/datactl:latest export pull
+   ```
+6. Commit
+   ```
+   docker run --rm \
+   --name datactl \
+   --mount type=bind,source=$HOME/.datactl,target=/root/.datactl \
+   --mount type=bind,source=$HOME/.kube,target=/root/.kube \
+   quay.io/rh-marketplace/datactl:latest export commit
+  ```

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+fips-detect /usr/local/bin/datactl
+datactl $@


### PR DESCRIPTION
Build and release options for fips enabled containerized version of datactl

- Can `make docker-build` and execute the commands from the container version; see README
- On release, will publish container to `quay.io/rh-marketplace/datactl`