### PR TITLE
fix: add licenses check

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -19,6 +19,9 @@ jobs:
         with:
           go-version: 1.19.10
 
+      - name: Check Licenses
+        run: make licenses-check
+
       - name: Build
         run: go build -v ./...
 

--- a/Makefile
+++ b/Makefile
@@ -70,3 +70,12 @@ tools:
 	go mod download
 	go install "k8s.io/code-generator/cmd/conversion-gen@v0.24.12"	
 	go install "sigs.k8s.io/controller-tools/cmd/controller-gen@v0.10.0"
+
+go-licenses:
+	go install "github.com/google/go-licenses@latest"
+
+licenses-check: go-licenses
+	go-licenses check --include_tests ./...
+
+licenses-save: go-licenses
+	go-licenses save --include_tests ./... --save_path=licenses


### PR DESCRIPTION
- use the go-licenses check tool to check licenses in the build process
depends on #35 for fix to goreleaser build task