### PR TITLE
fix: codeql warnings

### DIFF
--- a/pkg/bundle/bundle_file.go
+++ b/pkg/bundle/bundle_file.go
@@ -61,6 +61,9 @@ func (f *BundleFile) open(fileName string) error {
 	}
 
 	info, err := file.Stat()
+	if err != nil {
+		return err
+	}
 
 	// if the tar file has been written to previously, we need to remove the last
 	// 1024 bytes to append new files

--- a/pkg/clients/ilmt/ilmt.go
+++ b/pkg/clients/ilmt/ilmt.go
@@ -25,7 +25,6 @@ import (
 	"io/ioutil"
 	"log"
 	"net/http"
-	"os"
 	"regexp"
 	"strconv"
 	"strings"
@@ -89,19 +88,16 @@ func (ilmtC *ilmtClient) FetchUsageData(ctx context.Context, dateRange DateRange
 		urlForStandaloneProductUsage, err := ilmtC.req.FetchUsageData(ctx, ilmtC.IlmtConfig.Host, ilmtC.IlmtConfig.Token, CRITERIA_STANDALONE, strings.Split(selectedDate.String(), BLANK_VALUE)[0], strings.Split(selectedDate.String(), BLANK_VALUE)[0])
 		if err != nil {
 			log.Fatal(err.Error())
-			return -1, EMPTY, err
 		}
 
 		urlForProductPartOfBndlUsage, err := ilmtC.req.FetchUsageData(ctx, ilmtC.IlmtConfig.Host, ilmtC.IlmtConfig.Token, CRITEIRA_PRODUCTPARTOFBNDL, strings.Split(selectedDate.String(), BLANK_VALUE)[0], strings.Split(selectedDate.String(), BLANK_VALUE)[0])
 		if err != nil {
 			log.Fatal(err.Error())
-			return -1, EMPTY, err
 		}
 
 		urlForParentProductUsage, err := ilmtC.req.FetchUsageData(ctx, ilmtC.IlmtConfig.Host, ilmtC.IlmtConfig.Token, CRITERIA_PARENTPRODUCT, strings.Split(selectedDate.String(), BLANK_VALUE)[0], strings.Split(selectedDate.String(), BLANK_VALUE)[0])
 		if err != nil {
 			log.Fatal(err.Error())
-			return -1, EMPTY, err
 		}
 
 		// licence usage for product
@@ -109,13 +105,11 @@ func (ilmtC *ilmtClient) FetchUsageData(ctx context.Context, dateRange DateRange
 
 		if err != nil {
 			log.Fatal(err.Error())
-			return -1, EMPTY, err
 		}
 
 		standaloneProductRespData, err := ioutil.ReadAll(standaloneProductResp.Body)
 		if err != nil {
 			log.Fatal(err.Error())
-			return -1, EMPTY, err
 		}
 
 		var standaloneProductRespObj StandaloneProductResp
@@ -125,13 +119,11 @@ func (ilmtC *ilmtClient) FetchUsageData(ctx context.Context, dateRange DateRange
 		productPartOfBndlResp, err := ilmtC.Do(urlForProductPartOfBndlUsage)
 		if err != nil {
 			log.Fatal(err.Error())
-			return -1, EMPTY, err
 		}
 
 		productPartOfBndlRespData, err := ioutil.ReadAll(productPartOfBndlResp.Body)
 		if err != nil {
 			log.Fatal(err.Error())
-			return -1, EMPTY, err
 		}
 
 		var productPartOfBndlRespObj ProductPartOfBndlResp
@@ -141,13 +133,11 @@ func (ilmtC *ilmtClient) FetchUsageData(ctx context.Context, dateRange DateRange
 		parentProductResp, err := ilmtC.Do(urlForParentProductUsage)
 		if err != nil {
 			log.Fatal(err.Error())
-			return -1, EMPTY, err
 		}
 
 		parentProductRespData, err := ioutil.ReadAll(parentProductResp.Body)
 		if err != nil {
 			log.Fatal(err.Error())
-			return -1, EMPTY, err
 		}
 
 		var parentProductRespObj ParentProductResp
@@ -206,7 +196,6 @@ func (ilmtC *ilmtClient) FetchUsageData(ctx context.Context, dateRange DateRange
 			parentProductId, parentProductName, metricId, err := GetParentProduct(prodPartOfBundle, parentProductRespObj)
 			if err != nil {
 				log.Fatal(err.Error())
-				os.Exit(1)
 			}
 			host := ilmtC.IlmtConfig.Host[8:38]
 			BELL := '\a'

--- a/pkg/clients/marketplace/metrics.go
+++ b/pkg/clients/marketplace/metrics.go
@@ -192,6 +192,9 @@ func (r *marketplaceMetricClient) makeFormFile(fileName string, file []byte) (fo
 func (r *marketplaceMetricClient) uploadFile(ctx context.Context, form []byte, formContent string) (id string, err error) {
 	var req *http.Request
 	req, err = http.NewRequestWithContext(ctx, "POST", fmt.Sprintf(marketplaceMetricsPath, r.client.URL), bytes.NewReader(form))
+	if err != nil {
+		return "", err
+	}
 	req.Header.Set("Content-Type", formContent)
 
 	// Perform the request

--- a/pkg/datactl/config/client_builder.go
+++ b/pkg/datactl/config/client_builder.go
@@ -177,6 +177,9 @@ func (config *DirectClientConfig) RawConfig() (*datactlapi.Config, error) {
 
 func (config *DirectClientConfig) MarketplaceClientConfig() (*marketplace.MarketplaceConfig, error) {
 	mktplConfig, err := clients.ProvideMarketplaceUpload(&config.config)
+	if err != nil {
+		return nil, err
+	}
 
 	logger.Info("TLS", "MinVersion", config.overrides.MinVersion)
 	tlsVersion, err := k8sapiflag.TLSVersion(config.overrides.MinVersion)

--- a/pkg/datactl/config/config.go
+++ b/pkg/datactl/config/config.go
@@ -298,7 +298,9 @@ func writeConfig(
 			return err
 		}
 		writeFile, err := mutate(currConfig)
-
+		if err != nil {
+			return err
+		}
 		if !writeFile {
 			return nil
 		}


### PR DESCRIPTION
For: https://github.com/redhat-marketplace/datactl/security/code-scanning

- log.Fatal exits, return/exit is unreachable
- missing `err != nil` checks