### PR TITLE
fix: ubi9

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,9 @@
-FROM registry.access.redhat.com/ubi8/go-toolset:1.21 AS build
+FROM registry.access.redhat.com/ubi9/go-toolset:1.21 AS build
 ARG TARGETPLATFORM
 ARG BUILDPLATFORM
 ARG TARGETOS
 ARG TARGETARCH
+ARG FIPS_DETECT_VERSION=7157dae
 
 # Binary and pkg destination
 RUN mkdir -p /opt/app-root/src/go/bin && \
@@ -18,10 +19,10 @@ RUN --mount=type=bind,source=.,readonly,target=/opt/app-root/src/go/src/github.c
     go version && \
     go mod download && \
     GOFLAGS="-buildvcs=false" go install ./cmd/datactl && \
-    go install github.com/acardace/fips-detect@latest
+    go install github.com/acardace/fips-detect@${FIPS_DETECT_VERSION}
 
 
-FROM registry.access.redhat.com/ubi8/ubi-minimal
+FROM registry.access.redhat.com/ubi9/ubi-minimal
 ARG TARGETPLATFORM
 ARG BUILDPLATFORM
 ARG TARGETOS

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,6 @@ ARG TARGETPLATFORM
 ARG BUILDPLATFORM
 ARG TARGETOS
 ARG TARGETARCH
-ARG FIPS_DETECT_VERSION=7157dae
 
 # Binary and pkg destination
 RUN mkdir -p /opt/app-root/src/go/bin && \
@@ -18,8 +17,7 @@ RUN --mount=type=bind,source=.,readonly,target=/opt/app-root/src/go/src/github.c
     cd /opt/app-root/src/go/src/github.com/redhat-marketplace/datactl && \
     go version && \
     go mod download && \
-    GOFLAGS="-buildvcs=false" go install ./cmd/datactl && \
-    go install github.com/acardace/fips-detect@${FIPS_DETECT_VERSION}
+    GOFLAGS="-buildvcs=false" go install ./cmd/datactl
 
 
 FROM registry.access.redhat.com/ubi9/ubi-minimal
@@ -29,7 +27,6 @@ ARG TARGETOS
 ARG TARGETARCH
 
 COPY --from=build /opt/app-root/src/go/bin/datactl /usr/local/bin/datactl
-COPY --from=build /opt/app-root/src/go/bin/fips-detect /usr/local/bin/fips-detect
 COPY entrypoint.sh .
 
 ENV OPENSSL_FORCE_FIPS_MODE=1

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,3 +1,2 @@
 #!/bin/sh
-fips-detect /usr/local/bin/datactl
 datactl $@


### PR DESCRIPTION
- ubi9
- remove fips-detect

For UBI9, openssl v3, the GetSymbolPointer for `FIPS_mode` in fips-detect is no longer correct and leads to an error.

https://github.com/acardace/fips-detect/blob/main/pkg/fips/fips.go#L115

It may be that a Get for [EVP_default_properties_is_fips_enabled](https://docs.openssl.org/3.0/man3/EVP_set_default_properties/) would be a correct substitution
https://github.com/dacleyra/fips-detect/blob/main/pkg/fips/fips.go#L115

https://docs.openssl.org/3.0/man3/

In any case, at this point we have confidence we are building with openssl fips with the ubi go-toolset, so the tool is not necessary.