### PR TITLE
fix: revert to go-toolset 1.22.7

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi9/go-toolset:1.22.9 AS build
+FROM registry.access.redhat.com/ubi9/go-toolset:1.22.7 AS build
 ARG TARGETPLATFORM
 ARG BUILDPLATFORM
 ARG TARGETOS


### PR DESCRIPTION
issues with 1.22.9 ppc64le
https://github.com/redhat-marketplace/datactl/actions/runs/12936044620/job/36083330987